### PR TITLE
Added the option to filer emails in the query 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ If everything is done right, the last output from the script should be
 `token_path`: Path to OAuth2 token file.<br>
 `options`: <br>
 
+* `from`: String. Filter on the email address of the receiver.
+* `to`: String. Filter on the email address of the sender.
+* `subject`: String. Filter on the subject of the email.
 * `include_body`: boolean. Set to `true` to fetch decoded email bodies.
 * `before`: Date. Filter messages received _after_ the specified date.
 * `after`: Date. Filter messages received _before_ the specified date.
@@ -159,20 +162,16 @@ describe("Email assertion:", () => {
     cy
       .task("gmail:get-messages", {
         options: {
+          from: "AccountSupport@ubi.com",
+          subject: "Ubisoft Password Change Request",
           include_body: true,
           before: new Date(2019, 8, 1),
           after: new Date(2019, 3, 29)
         }
       })
       .then(emails => {
-        const found_email = emails.find(email => {
-          return (
-            email.from.indexOf("AccountSupport@ubi.com") >= 0 &&
-            email.subject.indexOf("Ubisoft Password Change Request") >= 0
-          );
-        });
-        assert.isNotNull(found_email, "Found email!");
-        const body = found_email.body.html;
+        expect(emails[0].from).to.exist
+        const body = emails[0].body.html;
         assert.isTrue(
           body.indexOf(
             "https://account-uplay.ubi.com/en-GB/action/change-password?genomeid="

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ describe("Email assertion:", () => {
           from: "AccountSupport@ubi.com",
           subject: "Ubisoft Password Change Request",
           include_body: true,
-          before: new Date (2019, 8, 24, 12, 31, 13) // Before September 24rd, 2019 12:31:13
+          before: new Date (2019, 8, 24, 12, 31, 13), // Before September 24rd, 2019 12:31:13
           after: new Date(2019, 7, 23)  // After August 23, 2019
         }
       })

--- a/README.md
+++ b/README.md
@@ -165,8 +165,10 @@ describe("Email assertion:", () => {
           from: "AccountSupport@ubi.com",
           subject: "Ubisoft Password Change Request",
           include_body: true,
-          before: new Date(2019, 8, 1),
-          after: new Date(2019, 3, 29)
+          before: Cypress.moment().toDate(), // Using moments to determine current date and time
+          after: new Date(2019, 8, 23) // Before September 23rd, 2019
+          // Extra precision for the dates can be achieved by adding hours,
+          // hours and minutes or hours, minutes and seconds
         }
       })
       .then(emails => {

--- a/README.md
+++ b/README.md
@@ -165,10 +165,8 @@ describe("Email assertion:", () => {
           from: "AccountSupport@ubi.com",
           subject: "Ubisoft Password Change Request",
           include_body: true,
-          before: Cypress.moment().toDate(), // Using moments to determine current date and time
-          after: new Date(2019, 8, 23) // Before September 23rd, 2019
-          // Extra precision for the dates can be achieved by adding hours,
-          // hours and minutes or hours, minutes and seconds
+          before: new Date (2019, 8, 24, 12, 31, 13) // Before September 24rd, 2019 12:31:13
+          after: new Date(2019, 7, 23)  // After August 23, 2019
         }
       })
       .then(emails => {

--- a/examples/cypress/integration/gmail.spec.js
+++ b/examples/cypress/integration/gmail.spec.js
@@ -3,25 +3,25 @@
 describe("Email assertion:", () => {
   it("Look for an email with specific subject and link in email body", function() {
     // debugger; //Uncomment for debugger to work...
-    cy.task("gmail:get-messages", {
-      options: {
-        include_body: true
-      }
-    }).then(emails => {
-      const found_email = emails.find(email => {
-        return (
-          email.from.indexOf("AccountSupport@ubi.com") >= 0 &&
-          email.subject.indexOf("Ubisoft Password Change Request") >= 0
+    cy
+      .task("gmail:get-messages", {
+        options: {
+          from: "AccountSupport@ubi.com",
+          subject: "Ubisoft Password Change Request",
+          include_body: true,
+          before: new Date (2019, 8, 24, 12, 31, 13), // Before September 24rd, 2019 12:31:13
+          after: new Date(2019, 7, 23)  // After August 23, 2019
+        }
+      })
+      .then(emails => {
+        expect(emails[0].from).to.exist
+        const body = emails[0].body.html;
+        assert.isTrue(
+          body.indexOf(
+            "https://account-uplay.ubi.com/en-GB/action/change-password?genomeid="
+          ) >= 0,
+          "Found reset link!"
         );
       });
-      assert.isNotNull(found_email, "Found email!");
-      const body = found_email.body.html;
-      assert.isTrue(
-        body.indexOf(
-          "https://account-uplay.ubi.com/en-GB/action/change-password?genomeid="
-        ) >= 0,
-        "Found reset link!"
-      );
-    });
   });
 });

--- a/gmail-tester.js
+++ b/gmail-tester.js
@@ -9,8 +9,8 @@ function _get_header(name, headers) {
 }
 
 function _init_query(options) {
-  const {to, from, subject, before, after } = options;
-  let query = "";
+  const { to, from, subject, before, after } = options;
+  const query = "";
   if (to) {
     query += `to:(${to})`;
   }
@@ -21,17 +21,16 @@ function _init_query(options) {
     query += `subject:(${subject})`;
   }
   if (after) {
-    var afterEpoch = Math.round(new Date(after).getTime()/1000)
-    query += `after:${afterEpoch}`;
+    const after_epoch = Math.round(new Date(after).getTime() / 1000)
+    query += `after:${after_epoch}`;
   }
   if (before) {
-    var beforeEpoch = Math.round(new Date(before).getTime()/1000)
-    query += `before:${beforeEpoch}`;
+    const before_epoch = Math.round(new Date(before).getTime() / 1000)
+    query += `before:${before_epoch}`;
   }
   query = query.trim();
   return query;
 }
-
 
 async function _get_recent_email(credentials_json, token_path, options = {}) {
   const emails = [];

--- a/gmail-tester.js
+++ b/gmail-tester.js
@@ -12,7 +12,7 @@ function _init_query(options) {
   const {to, from, subject, before, after } = options;
   let query = "";
   if (to) {
-    query += `to:(${from})`;
+    query += `to:(${to})`;
   }
   if (from) {
     query += `from:(${from})`;

--- a/gmail-tester.js
+++ b/gmail-tester.js
@@ -9,13 +9,21 @@ function _get_header(name, headers) {
 }
 
 function _init_query(options) {
-  const { before, after } = options;
+  const {from, subject, before, after } = options;
   let query = "";
-  if (before) {
-    query += `before:${before.getFullYear()}/${before.getMonth()}/${before.getDate()} `;
+  if (from) {
+    query += `from:(${from})`;
+  }
+  if (subject) {
+    query += `subject:(${subject})`;
   }
   if (after) {
-    query += `after:${after.getFullYear()}/${after.getMonth()}/${after.getDate()} `;
+    var afterEpoch = Math.round(new Date(after).getTime()/1000)
+    query += `after:${afterEpoch}`;
+  }
+  if (before) {
+    var beforeEpoch = Math.round(new Date(before).getTime()/1000)
+    query += `before:${beforeEpoch}`;
   }
   query = query.trim();
   return query;

--- a/gmail-tester.js
+++ b/gmail-tester.js
@@ -9,8 +9,11 @@ function _get_header(name, headers) {
 }
 
 function _init_query(options) {
-  const {from, subject, before, after } = options;
+  const {to, from, subject, before, after } = options;
   let query = "";
+  if (to) {
+    query += `to:(${from})`;
+  }
   if (from) {
     query += `from:(${from})`;
   }
@@ -28,6 +31,7 @@ function _init_query(options) {
   query = query.trim();
   return query;
 }
+
 
 async function _get_recent_email(credentials_json, token_path, options = {}) {
   const emails = [];


### PR DESCRIPTION
Hi,

Thank you so much for adding the add feature. I was the one requested it and I have used it already.

The new code also gave me the pointers to adjust and expand the features.

I have added the option to filter the emails in the query. Now it is possible to just download the emails you need, so you do not need to have an extra function filtering the results afterwards. It is possible to select emails on sender, receiver and subject. Receiver is something I mostly added for myself, since I tend to use the feature of gmail a lot where you can add "+${string}" after your username to generate a unique email address.

I have also changed the way the _init_query_ handles the dates, so it is possible to have more precise search parameters. By using epoch it is possible to define the cut-off moments on the second. This is useful if you want to run a test multiple times on one day or if you need to make sure emails arrive within a certain period after sending them.

Additionally I have updated the readme to reflect the changes I made. I have added a remark to make it clear how to define the date.

This is my first pull request, so please let me know if I made any mistakes.