### PR TITLE
feat(email): added options to check_inbox function

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ const email = await gmail.check_inbox(
   "<target-email>", // Which inbox to poll. credentials.json should contain the credentials to it.
   10, // Poll interval (in seconds).
   30 // Maximum poll time (in seconds), after which we'll giveup.
+  { include_body: true } // If we want to include the body of messages (optional)
+  ]
 );
 if (email) {
   console.log("Email was found!");

--- a/gmail-tester.js
+++ b/gmail-tester.js
@@ -86,7 +86,8 @@ async function check_inbox(
   from,
   to,
   wait_time_sec = 30,
-  max_wait_time_sec = 60
+  max_wait_time_sec = 60,
+  options
 ) {
   try {
     console.log(
@@ -96,7 +97,7 @@ async function check_inbox(
     let found_email = null;
     let done_waiting_time = 0;
     do {
-      const emails = await _get_recent_email(credentials_json, token_path);
+      const emails = await _get_recent_email(credentials_json, token_path, options);
       for (let email of emails) {
         if (
           email.receiver === to &&


### PR DESCRIPTION
## Context

The `check_inbox` function doesn't accept an `options` whereas the `_get_recent_email` has. This is annoying since this prevents from passing the `include_body`option to get the content of the email.

## Feature

The updates allow cypress tests to do something like that:

```
  on("task", {
    "gmail:check": async args => {
      const { from, to, subject } = args;
      const email = await gmail.check_inbox(
        path.resolve(__dirname, "credentials.json"), // credentials.json is inside plugins/ directory.
        path.resolve(__dirname, "gmail_token.json"), // gmail_token.json is inside plugins/ directory.
        subject,
        from,
        to,
        10,                                          // Poll interval (in seconds)
        30                                           // Maximum poll interval (in seconds). If reached, return null, indicating the completion of the task().
       { include_body: true }
      );
      return email;
    },
``` 