### PR TITLE
Add support for multipart mime type

### DIFF
--- a/gmail-tester.js
+++ b/gmail-tester.js
@@ -69,21 +69,19 @@ async function _get_recent_email(credentials_json, token_path, options = {}) {
             break;
         }
       } else {
-        let body_part = gmail_email.payload.parts.find(
-          p => p.mimeType === "text/html"
-        );
-        if (body_part) {
-          email_body.html = Buffer.from(body_part.body.data, "base64").toString(
-            "utf8"
-          );
-        }
-        body_part = gmail_email.payload.parts.find(
-          p => p.mimeType === "text/plain"
-        );
-        if (body_part) {
-          email_body.text = Buffer.from(body_part.body.data, "base64").toString(
-            "utf8"
-          );
+        let { parts } = gmail_email.payload;
+        while (parts.length) {
+          let part = parts.shift()
+
+          if (part.parts)
+            parts = parts.concat(part.parts)
+
+          if (part.mimeType === 'text/plain')
+          email_body.text = Buffer.from(part.body.data, "base64").toString("utf8")
+
+          if (part.mimeType === 'text/html')
+          email_body.html = Buffer.from(part.body.data, "base64").toString("utf8")
+
         }
       }
 


### PR DESCRIPTION
When mail has attachments or embedded images it comes with `multipart/related` mime type.
In this case we need to deal with nested parts of email.
This PR adds flattening array of `parts` in case of any nested `parts` until we find needed mime types for parsing email body (`'text/plain' and 'text/html`)

```
[
  {
    partId: '0',
    mimeType: 'multipart/related',
    filename: '',
    headers: [ [Object] ],
    body: { size: 0 },
    parts: [ [Object] ]
  }
]
[
  {
    partId: '0',
    mimeType: 'multipart/related',
    filename: '',
    headers: [ [Object] ],
    body: { size: 0 },
    parts: [ [Object] ]
  }
]
[
  {
    partId: '0',
    mimeType: 'multipart/related',
    filename: '',
    headers: [ [Object] ],
    body: { size: 0 },
    parts: [ [Object] ]
  }
]
[
  {
    partId: '0',
    mimeType: 'multipart/related',
    filename: '',
    headers: [ [Object] ],
    body: { size: 0 },
    parts: [ [Object] ]
  }
]
[
  {
    partId: '0',
    mimeType: 'multipart/related',
    filename: '',
    headers: [ [Object] ],
    body: { size: 0 },
    parts: [ [Object] ]
  }
]
```