### PR TITLE
README.md: update readme to use Desktop app as application type

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The process should look like this:
 
 # How to get credentials.json?
 
-1.  Follow the instructions to [Create a client ID and client secret](https://developers.google.com/adwords/api/docs/guides/authentication#create_a_client_id_and_client_secret). Make sure to select `Other` for the application type.
+1.  Follow the instructions to [Create a client ID and client secret](https://developers.google.com/adwords/api/docs/guides/authentication#create_a_client_id_and_client_secret). Make sure to select `Desktop app` for the application type.
 2.  Once done, go to [https://console.cloud.google.com/apis/credentials?project=(project-name)&folder&organizationId](<https://console.cloud.google.com/apis/credentials?project=(project-name)&folder&organizationId>) and download the OAuth2 credentials file, as shown in the image below. Make sure to replace `(project-name)` with your project name.
 
     <p align="center">


### PR DESCRIPTION
Gmail api no longer allows to select `Other` as application type while creating OAuth credentials. However, the steps mentioned in README can be successfully achieved by setting application type as `Desktop app`. It seems few people have faced problems and reported issues (which are closed) due to this, example : #40. This PR is intended to update the selection made while setting application type. Kindly review. Thank you.

@levz0r 