### PR TITLE
Add support for fetching attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Congratulations! `gmail-tester` is ready to use.
 - `to`: String. Filter on the email address of the sender.
 - `subject`: String. Filter on the subject of the email.
 - `include_body`: boolean. Set to `true` to fetch decoded email bodies.
-- `include_attachments`: boolean. Set to `true` to fetch decoded email attachments.
+- `include_attachments`: boolean. Set to `true` to fetch the base64-encoded email attachments.
 - `before`: Date. Filter messages received _after_ the specified date.
 - `after`: Date. Filter messages received _before_ the specified date.
 - `label`: String. The default label is 'INBOX', but can be changed to 'SPAM', 'TRASH' or a custom label. For a full list of built-in labels, see https://developers.google.com/gmail/api/guides/labels?hl=en

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Congratulations! `gmail-tester` is ready to use.
 - `to`: String. Filter on the email address of the sender.
 - `subject`: String. Filter on the subject of the email.
 - `include_body`: boolean. Set to `true` to fetch decoded email bodies.
+- `include_attachments`: boolean. Set to `true` to fetch decoded email attachments.
 - `before`: Date. Filter messages received _after_ the specified date.
 - `after`: Date. Filter messages received _before_ the specified date.
 - `label`: String. The default label is 'INBOX', but can be changed to 'SPAM', 'TRASH' or a custom label. For a full list of built-in labels, see https://developers.google.com/gmail/api/guides/labels?hl=en

--- a/gmail-tester.js
+++ b/gmail-tester.js
@@ -95,17 +95,17 @@ async function _get_recent_email(credentials_json, token_path, options = {}) {
     if (options.include_attachments) {
       const parts = gmail_email.payload.parts || [];
       const attachmentInfos = parts.filter(part => part.body.size && part.body.attachmentId)
-        .map(part => ({ id: part.body.attachmentId, filename: part.filename }));
+        .map(({ body, filename, mimeType }) => ({ id: body.attachmentId, filename, mimeType }));
 
       email.attachments = await Promise.all(
-        attachmentInfos.map(async ({ id, filename }) => {
+        attachmentInfos.map(async ({ id, filename, mimeType }) => {
           const { data: { data: base64Data } } = await gmail_client.users.messages.attachments.get({
             auth: oAuth2Client,
             userId: 'me',
             messageId: gmail_email.id,
             id
           });
-          return { data: base64Data, filename };
+          return { data: base64Data, filename, mimeType };
         })
       );
     }

--- a/gmail-tester.js
+++ b/gmail-tester.js
@@ -69,7 +69,7 @@ async function _get_recent_email(credentials_json, token_path, options = {}) {
             break;
         }
       } else {
-        let { parts } = gmail_email.payload;
+        const parts = [...gmail_email.payload.parts];
         while (parts.length) {
           let part = parts.shift();
 

--- a/gmail-tester.js
+++ b/gmail-tester.js
@@ -105,7 +105,7 @@ async function _get_recent_email(credentials_json, token_path, options = {}) {
             messageId: gmail_email.id,
             id
           });
-          return { data: Buffer.from(base64Data, 'base64').toString(), filename };
+          return { data: base64Data, filename };
         })
       );
     }


### PR DESCRIPTION
This adds an `include_attachments` option to `get_messages`. If set, an `attachments` field is included in the returned `email` object, containing an entry for each attachment, of the form `{ data: string, filename: string, mimeType: string }`. The data is left encoded as base64. 