### PR TITLE
Typing: `label` is an optional parameter

### DIFF
--- a/gmail-tester.d.ts
+++ b/gmail-tester.d.ts
@@ -19,7 +19,7 @@ declare module "gmail-tester" {
     after?: Date;
     wait_time_sec?: number;
     max_wait_time_sec?: number;
-    label: string;
+    label?: string;
   }
 
   export interface GetMessagesOptions {


### PR DESCRIPTION
The docs on `check_inbox` say that `label` defaults to `"INBOX"`, but the typescript typings have it marked as a required parameter.

https://github.com/levz0r/gmail-tester/blob/434f791d5810cfd179d2cf0819f24f8b6564f5d9/gmail-tester.js#L167