### PR TITLE
fix(get-recent-email): handle attachment body part

### DIFF
--- a/gmail-tester.js
+++ b/gmail-tester.js
@@ -72,6 +72,12 @@ async function _get_recent_email(credentials, token, options = {}) {
           if (part.parts) {
             parts = parts.concat(part.parts);
           }
+          
+          if (!part.body.data) {
+            // body part could be an attachment of type text/plain or text/html
+            // and the parsing code below will break, hence skipping here
+            continue;
+          }
 
           if (part.mimeType === "text/plain") {
             email_body.text = Buffer.from(part.body.data, "base64").toString(


### PR DESCRIPTION
Sometimes, the attachments could be of type `text/plain` or `text/html` and mistaken for a email body part while being an attachment (Please see attached screenshot).

![Screenshot 2022-11-16 at 10 43 59 AM](https://user-images.githubusercontent.com/12974927/202070905-8706cbac-2397-4c67-ade7-c70a3729728a.png)

I'm proposing that we should apply a blanket check to skip processing the body part if it doesn't have a body
