### PR TITLE
Add custom port configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ The process should look like this:
 
 5.  **Add authorized redirect URI:**
     - Go to your OAuth 2.0 Client ID settings
-    - Under "Authorized redirect URIs", add `http://localhost` (or `http://localhost:<port>` if using a custom port)
+    - Under "Authorized redirect URIs", add `http://localhost:32019`
+    - If using a custom port, add `http://localhost:<your-port>` instead
 
 If everything is done right, the last output from the script should be:
 

--- a/gmail-tester.js
+++ b/gmail-tester.js
@@ -196,7 +196,7 @@ async function check_inbox(
  */
 async function get_messages(credentials, token, options, port = 32019) {
   try {
-    return await _get_recent_email(credentials, token, options, port = 32019);
+    return await _get_recent_email(credentials, token, options, port);
   } catch (err) {
     console.log("[gmail] Error:", err);
   }
@@ -210,7 +210,7 @@ async function get_messages(credentials, token, options, port = 32019) {
  * @param {number} [port] - Optional port option, in case the default port (32019) is unavailable. 
  */
 async function refresh_access_token(credentials, token, port = 32019) {
-  const oAuth2Client = await gmail.authorize(credentials, token, port = 32019);
+  const oAuth2Client = await gmail.authorize(credentials, token, port);
   const refresh_token_result = await oAuth2Client.refreshToken(
     oAuth2Client.credentials.refresh_token
   );

--- a/gmail-tester.js
+++ b/gmail-tester.js
@@ -30,16 +30,17 @@ function _init_query(options) {
   return query;
 }
 
-async function _get_recent_email(credentials, token, options = {}) {
+async function _get_recent_email(credentials, token, options = {}, port = 32019) {
   const emails = [];
 
   const query = _init_query(options);
   // Load client secrets from a local file.
-  const oAuth2Client = await gmail.authorize(credentials, token);
+  const oAuth2Client = await gmail.authorize(credentials, token, port);
   const gmail_emails = await gmail.get_recent_email(
     oAuth2Client,
     query,
-    options.label
+    options.label,
+    port
   );
   for (const gmail_email of gmail_emails) {
     const email = {
@@ -103,7 +104,7 @@ async function _get_recent_email(credentials, token, options = {}) {
   return emails;
 }
 
-async function __check_inbox(credentials, token, options = {}) {
+async function __check_inbox(credentials, token, options = {}, port = 32019) {
   const { subject, from, to, wait_time_sec, max_wait_time_sec } = options;
   try {
     console.log(
@@ -115,7 +116,8 @@ async function __check_inbox(credentials, token, options = {}) {
       const emails = await _get_recent_email(
         credentials,
         token,
-        options
+        options,
+        port
       );
       if (emails.length > 0) {
         console.log(`[gmail] Found!`);
@@ -154,6 +156,7 @@ async function __check_inbox(credentials, token, options = {}) {
  * @param {number} [options.wait_time_sec] - Interval between inbox checks (in seconds). Default: 30 seconds.
  * @param {number} [options.max_wait_time_sec] - Maximum wait time (in seconds). When reached and the email was not found, the script exits. Default: 60 seconds.
  * @param {string} [options.label] - String. The default label is 'INBOX', but can be changed to 'SPAM', 'TRASH' or a custom label. For a full list of built-in labels, see https://developers.google.com/gmail/api/guides/labels?hl=en
+ * @param {number} [port] - Optional port option, in case the default port (32019) is unavailable.
  */
 async function check_inbox(
   credentials,
@@ -166,7 +169,8 @@ async function check_inbox(
     max_wait_time_sec: 30,
     include_body: false,
     label: "INBOX"
-  }
+  },
+  port = 32019
 ) {
   if (typeof options !== "object") {
     console.error(
@@ -174,7 +178,7 @@ async function check_inbox(
     );
     process.exit(1);
   }
-  return __check_inbox(credentials, token, options);
+  return __check_inbox(credentials, token, options, port);
 }
 
 /**
@@ -189,10 +193,11 @@ async function check_inbox(
  * @param {string} options.subject - Filter on the subject of the email.
  * @param {Object} options.before - Date. Filter messages received _after_ the specified date.
  * @param {Object} options.after - Date. Filter messages received _before_ the specified date.
+ * @param {number} [port] - Optional port option, in case the default port (32019) is unavailable. 
  */
-async function get_messages(credentials, token, options) {
+async function get_messages(credentials, token, options, port = 32019) {
   try {
-    return await _get_recent_email(credentials, token, options);
+    return await _get_recent_email(credentials, token, options, port = 32019);
   } catch (err) {
     console.log("[gmail] Error:", err);
   }
@@ -203,9 +208,10 @@ async function get_messages(credentials, token, options) {
  *
  * @param {string | Object} credentials - Path to credentials json file or credentials Object.
  * @param {string | Object} token - Path to token json file or token Object.
+ * @param {number} [port] - Optional port option, in case the default port (32019) is unavailable. 
  */
-async function refresh_access_token(credentials, token) {
-  const oAuth2Client = await gmail.authorize(credentials, token);
+async function refresh_access_token(credentials, token, port = 32019) {
+  const oAuth2Client = await gmail.authorize(credentials, token, port = 32019);
   const refresh_token_result = await oAuth2Client.refreshToken(
     oAuth2Client.credentials.refresh_token
   );

--- a/gmail-tester.js
+++ b/gmail-tester.js
@@ -39,8 +39,7 @@ async function _get_recent_email(credentials, token, options = {}, port = 32019)
   const gmail_emails = await gmail.get_recent_email(
     oAuth2Client,
     query,
-    options.label,
-    port
+    options.label
   );
   for (const gmail_email of gmail_emails) {
     const email = {

--- a/gmail.js
+++ b/gmail.js
@@ -12,6 +12,7 @@ const SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"];
  * given callback function.
  * @param {string | Object} credentials The authorization client credentials.
  * @param {string | Object} token  Token.
+ * @param {number} [port] - Optional port option, in case the default port (32019) is unavailable.
  * @return {google.auth.OAuth2} The OAuth2Client.
  */
 async function authorize(credentials, token, port = 32019) {
@@ -41,6 +42,8 @@ async function authorize(credentials, token, port = 32019) {
  * Get a new token after prompting for user authorization, and then
  * execute the given callback with the authorized OAuth2 client.
  * @param {google.auth.OAuth2} oAuth2Client The OAuth2 client to get token for.
+ * @param {string | Object} token  Token.
+ * @param {number} [port] - Optional port option, in case the default port (32019) is unavailable.
  * @return {Promise<google.auth.OAuth2>} The promise for the authorized client.
  */
 async function get_new_token(oAuth2Client, token, port = 32019) {

--- a/gmail.js
+++ b/gmail.js
@@ -2,7 +2,7 @@ const readline = require("readline");
 const { google } = require("googleapis");
 const tokenStore = require("./token-store");
 const fs = require("fs");
-const { authenticate } = require("./libs/oauth2");
+const oauth2 = require("./libs/oauth2");
 
 // If modifying these scopes, delete token.json.
 const SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"];
@@ -28,7 +28,7 @@ async function authorize(credentials, token, port = 32019) {
     oAuth2Client.setCredentials(_get_token_object(token));
     return oAuth2Client;
   } catch (error) {
-    const newOAuth2Client = await get_new_token(oAuth2Client, token, port = 32019);
+    const newOAuth2Client = await get_new_token(oAuth2Client, token, port);
     if (token instanceof Object) {
       tokenStore.store(newOAuth2Client.credentials);
     } else {
@@ -47,7 +47,7 @@ async function authorize(credentials, token, port = 32019) {
  * @return {Promise<google.auth.OAuth2>} The promise for the authorized client.
  */
 async function get_new_token(oAuth2Client, token, port = 32019) {
-  return authenticate(oAuth2Client, SCOPES, token, port);
+  return oauth2.authenticate(oAuth2Client, SCOPES, token, port);
 }
 
 /**

--- a/gmail.js
+++ b/gmail.js
@@ -14,7 +14,7 @@ const SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"];
  * @param {string | Object} token  Token.
  * @return {google.auth.OAuth2} The OAuth2Client.
  */
-async function authorize(credentials, token) {
+async function authorize(credentials, token, port = 32019) {
   const { client_secret, client_id, redirect_uris } =
     _get_credentials_object(credentials).installed;
   const oAuth2Client = new google.auth.OAuth2(
@@ -27,7 +27,7 @@ async function authorize(credentials, token) {
     oAuth2Client.setCredentials(_get_token_object(token));
     return oAuth2Client;
   } catch (error) {
-    const newOAuth2Client = await get_new_token(oAuth2Client, token);
+    const newOAuth2Client = await get_new_token(oAuth2Client, token, port = 32019);
     if (token instanceof Object) {
       tokenStore.store(newOAuth2Client.credentials);
     } else {
@@ -43,8 +43,8 @@ async function authorize(credentials, token) {
  * @param {google.auth.OAuth2} oAuth2Client The OAuth2 client to get token for.
  * @return {Promise<google.auth.OAuth2>} The promise for the authorized client.
  */
-async function get_new_token(oAuth2Client, token) {
-  return authenticate(oAuth2Client, SCOPES, token);
+async function get_new_token(oAuth2Client, token, port = 32019) {
+  return authenticate(oAuth2Client, SCOPES, token, port);
 }
 
 /**

--- a/init.js
+++ b/init.js
@@ -2,12 +2,14 @@ const gmail = require("./gmail-tester");
 
 (async () => {
   if (process.argv.length < 5) {
-    console.error(`Usage: init.js <path-to-credentials.json> <path-to-token.json> <target-email>`)
+    console.error(`Usage: init.js <path-to-credentials.json> <path-to-token.json> <target-email> [port]`)
+    console.error(`  port: Optional. Default is 32019. Set a custom port if needed.`)
     process.exit(1)
   }
+  const port = process.argv[5] ? parseInt(process.argv[5], 10) : 32019;
   await gmail.check_inbox(process.argv[2], process.argv[3], {
     subject: "",
     from: "",
     to: process.argv[4]
-  });
+  }, port);
 })();

--- a/libs/oauth2.js
+++ b/libs/oauth2.js
@@ -32,7 +32,7 @@ if (fs.existsSync(keyPath)) {
 /**
  * Open an http server to accept the oauth callback. In this simple example, the only request to our webserver is to /callback?code=<code>
  */
-async function authenticate(oauth2Client, scopes, tokensFile, port = 80) {
+async function authenticate(oauth2Client, scopes, tokensFile, port = 32019) {
   return new Promise((resolve, reject) => {
     // grab the url that will be used for authorization
     if (!fs.existsSync(tokensFile)) {

--- a/spec/gmail.spec.js
+++ b/spec/gmail.spec.js
@@ -1,5 +1,6 @@
 const gmail = require('../gmail');
 const tokenStore = require('../token-store');
+const oauth2 = require('../libs/oauth2');
 
 const { google } = require('googleapis');
 
@@ -37,6 +38,49 @@ describe('Gmail', () => {
     expect(tokenStore.get).not.toHaveBeenCalled();
     expect(result).not.toBeNull();
     expect(oAuth2Spy.setCredentials).toHaveBeenCalledOnceWith({myObj: true});
+  });
+
+  it('authorize passes custom port to authenticate when getting new token', async () => {
+    const cred_obj = {"installed":{"client_secret":"client_secret","client_id":"client_id","redirect_uris":["redirect_uris"]}};
+
+    const oAuth2Spy = jasmine.createSpyObj('oAuth2', ['setCredentials']);
+    oAuth2Spy.setCredentials.and.throwError('Token not found');
+    oAuth2Spy.credentials = { access_token: 'new_token' };
+
+    spyOn(google.auth, 'OAuth2').and.returnValue(oAuth2Spy);
+    spyOn(oauth2, 'authenticate').and.returnValue(Promise.resolve(oAuth2Spy));
+    spyOn(tokenStore, 'store');
+
+    const customPort = 3000;
+    await gmail.authorize(cred_obj, 'token_path', customPort);
+
+    expect(oauth2.authenticate).toHaveBeenCalledWith(
+      oAuth2Spy,
+      ['https://www.googleapis.com/auth/gmail.readonly'],
+      'token_path',
+      customPort
+    );
+  });
+
+  it('authorize uses default port 32019 when no port specified', async () => {
+    const cred_obj = {"installed":{"client_secret":"client_secret","client_id":"client_id","redirect_uris":["redirect_uris"]}};
+
+    const oAuth2Spy = jasmine.createSpyObj('oAuth2', ['setCredentials']);
+    oAuth2Spy.setCredentials.and.throwError('Token not found');
+    oAuth2Spy.credentials = { access_token: 'new_token' };
+
+    spyOn(google.auth, 'OAuth2').and.returnValue(oAuth2Spy);
+    spyOn(oauth2, 'authenticate').and.returnValue(Promise.resolve(oAuth2Spy));
+    spyOn(tokenStore, 'store');
+
+    await gmail.authorize(cred_obj, 'token_path');
+
+    expect(oauth2.authenticate).toHaveBeenCalledWith(
+      oAuth2Spy,
+      ['https://www.googleapis.com/auth/gmail.readonly'],
+      'token_path',
+      32019
+    );
   });
 
 });


### PR DESCRIPTION
## Summary
- Add optional `port` parameter to all public API functions (`check_inbox`, `get_messages`, `refresh_access_token`)
- Fix bug where port parameter was being reassigned instead of passed through (3 locations)
- Change default port from 80 to 32019 (port 80 requires root/admin privileges)
- Update `init.js` to accept optional custom port argument
- Add redirect URI documentation to README

## Test plan
- [x] Added unit tests for port parameter passing
- [x] All 9 tests pass

Supersedes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)